### PR TITLE
3-core-osm-install-script-error

### DIFF
--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -12,4 +12,5 @@ sudo ln -sf $DIR/gbl.sh /bin/gbl
 tpl -i $DIR/tpls/bashrc.tpl -r -o $HOME/.bashrc -v BASHRC_INC=$DIR/gbl_bashrc.inc.sh
 sudo tpl -i $DIR/tpls/bashrc.tpl -r -o /root/.bashrc -v BASHRC_INC=$DIR/gbl_bashrc.inc.sh
 sudo -H apt install -y python-pip
+sudo -H apt install -y python-pip3
 sudo -H pip install pyyaml tabulate


### PR DESCRIPTION
python-pip3 is required for CORE installation